### PR TITLE
Add markdown boxes

### DIFF
--- a/glider_explorer.py
+++ b/glider_explorer.py
@@ -70,7 +70,7 @@ pn.extension(
     exception_handler=exception_handler,
     notifications=True,
     nthreads=0,
-    # defer_load=True,
+    # defer_load=True, # forgets to import important modules. Not useful.
 )
 
 text_opts = hv.opts.Text(text_align="left", text_color="black", fontsize=10)

--- a/glider_explorer.py
+++ b/glider_explorer.py
@@ -307,9 +307,19 @@ class GliderDashboard(param.Parameterized):
     endY = None
 
     def update_markdown(self, x_range, y_range):
+        metadata = lod.metadata
+        time_start = self.data_in_view.select("time").first().collect()[0, 0]
+        time_end = self.data_in_view.select("time").last().collect()[0, 0]
+        duration_d = (time_end - time_start).days
+        n_prof = int(
+            self.data_in_view.select("profile_num").last().collect()[0, 0]
+            - self.data_in_view.select("profile_num").first().collect()[0, 0]
+        )
+        max_d = self.data_in_view.select("depth").max().collect()[0, 0]
+
         p1 = """\
-             # About
-             Ocean """
+# About
+Ocean """
         for variable in self.pick_variables:
             description = (
                 f"{variable} in [{dictionaries.units_dict.get(variable, '')}], "
@@ -320,17 +330,112 @@ class GliderDashboard(param.Parameterized):
         else:  # self.pick_toggle == "SAMBA obs.":
             p2 = f"""for the region {self.pick_basin} """
         # try:
-        p3 = f"""from {self.data_in_view.select("time").first().collect()[0, 0]} to {self.data_in_view.select("time").last().collect()[0, 0]}. """
+        p3 = f"""from {time_start} to {time_end}. """
         # except:
         #    import pdb
         #    pdb.set_trace()
-        p4 = f"""Number of profiles {
-            self.data_in_view.select("profile_num").last().collect()[0, 0]
-            - self.data_in_view.select("profile_num").first().collect()[0, 0]
-        } """
+        p4 = f"""Number of profiles {n_prof}."""
 
-        self.markdown.object = p1 + p2 + p3 + p4  # +r"$$\frac{1}{n}$$"
-        return p1 + p2 + p3 + p4
+        #   Table 1: Basic summary of the view.
+        table1 = f"""
+<b>Data Summary</b>
+
+| Metric                | Value                     |
+|-----------------------|---------------------------|
+| Range Start           | {time_start.strftime("%Y-%m-%d %H:%M:%S")} |
+| Range End             | {time_end.strftime("%Y-%m-%d %H:%M:%S")}   |
+| Duration (Days)       | {duration_d}              |
+| Number of Profiles    | {n_prof}                  |
+| Maximum Depth (m)     | {max_d:.2f}               |
+"""
+
+        #   Table 2: Statistics for the picked variables in "Contour plot options".
+        def var_row(variable):
+            """For a specified variable, create a table row with basic stats"""
+            try:
+                min_val = self.data_in_view.select(variable).min().collect()[0, 0]
+                max_val = self.data_in_view.select(variable).max().collect()[0, 0]
+                mean_val = self.data_in_view.select(variable).mean().collect()[0, 0]
+                stdev_val = self.data_in_view.select(variable).std().collect()[0, 0]
+                return f"| {variable} | {min_val:.2f} / {max_val:.2f} / {mean_val:.2f} / {stdev_val:.2f} |"
+            except Exception as e:
+                print(f"Error calculating stats for {variable}: {e}")
+                return f"| {variable} | N/A |"
+
+        table_var_rows = []
+        for variable in self.pick_variables:
+            table_var_rows.append(var_row(variable))
+            if str(variable + "_qc") in self.data_in_view.collect_schema():
+                table_var_rows.append(var_row(variable + "_qc"))
+        table_var_to_add = "\n".join(table_var_rows)
+
+        table2 = f"""
+<b>Picked Variable Statistics</b>
+
+| Variable         | Min / Max / Mean / Stdev  |
+|------------------|---------------------------|
+{table_var_to_add}
+"""
+
+        #   Table 3: Pull the metadata for datasetIDs within the current time period.
+        current_meta = metadata[
+            (metadata["time_coverage_start (UTC)"] <= time_end)
+            & (metadata["time_coverage_end (UTC)"] >= time_start)
+        ]
+
+        meta_rows = ""
+        for (
+            idx,
+            row,
+        ) in current_meta.iterrows():
+            #   Create nested tables, summary formatting makes Parameters collapsible
+            params = "".join(
+                f"<tr><td>{col}</td><td>{row[col]}</td></tr>" for col in row.index
+            )
+            meta_rows += f"""
+<tr>
+<td>{idx}</td>
+<td>
+    <details>
+    <summary>Show parameters</summary>
+    <table>
+        <tr><th>Parameter</th><th>Value</th></tr>
+        {params}
+    </table>
+    </details>
+</td>
+</tr>
+"""
+
+        table3 = f"""
+<b>Datasets in Current Temporal View</b>
+
+<table>
+  <tr><th>DatasetID</th><th>Parameters</th></tr>
+  {meta_rows}
+</table>
+"""
+
+        tables_side_by_side = f"""
+<div style="display: flex; gap: 20px;">
+<div style="flex: 1;">
+{table1}
+</div>
+<div style="flex: 1;">
+{table2}
+</div>
+<div style="flex: 1;">
+{table3}
+</div>
+</div>
+"""
+        self.markdown.object = (
+            p1 + p2 + p3 + p4 + tables_side_by_side
+        )  # +r"$$\frac{1}{n}$$"
+        return p1 + p2 + p3 + p4 + tables_side_by_side
+        #   Max/min/mean values of chosen variables
+        #   List different missions, each collapsible, with list of sensors from metadata
+        #   Data quality flags for chosen variables? (add a link to QC sheets and scripts)
 
     # empty initialization for use later
     markdown = pn.pane.Markdown("")
@@ -793,6 +898,7 @@ class GliderDashboard(param.Parameterized):
                     "crosshair",  # show where the mouse is on axis
                     "box_zoom",  # zoom on selection along x
                     "undo",  # undo action
+                    "reset",  # reset view
                     "hover",
                     "tap",
                     "save",

--- a/glider_explorer.py
+++ b/glider_explorer.py
@@ -309,12 +309,12 @@ class GliderDashboard(param.Parameterized):
     def update_markdown(self, x_range, y_range):
         metadata = lod.metadata
 
-        if x_range == (None, None): #   Init to definition in the data
+        if x_range == (None, None):  #   Init to definition in the data
             time_start = self.data_in_view.select("time").first().collect()[0, 0]
             time_end = self.data_in_view.select("time").last().collect()[0, 0]
         else:
-            time_start = x_range[0].astype('datetime64[us]').astype('O')
-            time_end = x_range[1].astype('datetime64[us]').astype('O')
+            time_start = x_range[0].astype("datetime64[us]").astype("O")
+            time_end = x_range[1].astype("datetime64[us]").astype("O")
         duration_d = np.round((time_end - time_start) / np.timedelta64(1, "D"), 1)
         n_prof = int(
             self.data_in_view.select("profile_num").last().collect()[0, 0]

--- a/glider_explorer.py
+++ b/glider_explorer.py
@@ -306,7 +306,25 @@ class GliderDashboard(param.Parameterized):
     startY = None
     endY = None
 
-    def update_markdown(self, x_range, y_range):
+    def update_markdown(self, x_range: tuple, y_range: tuple) -> str:
+        """
+        Updates markdown information below the plots on the page based on the currently visible ranges of data.
+
+        y_range is typically `depth`.
+
+        Parameters
+        ----------
+        x_range : tuple of numpy.datetime64
+            The start[0] and end[1] of the X domain (time) currently visible data on the plot.
+        y_range : tuple of np.float64
+            The minimum[0] and maximum[1] of the Y domain currently visible on the plot.
+
+        Return
+        ------
+        all_markdown : str
+            String of updated markdown, including paragraph summaries of data within the view and tables
+            of statistics.
+        """
         metadata = lod.metadata
 
         if x_range == (None, None):  #   Init to definition in the data
@@ -434,11 +452,9 @@ Ocean """
 </div>
 </div>
 """
-        # breakpoint()
-        self.markdown.object = (
-            p1 + p2 + p3 + p4 + tables_side_by_side
-        )  # +r"$$\frac{1}{n}$$"
-        return p1 + p2 + p3 + p4 + tables_side_by_side
+        all_markdown = p1 + p2 + p3 + p4 + tables_side_by_side
+        self.markdown.object = all_markdown  # +r"$$\frac{1}{n}$$"
+        return all_markdown
         #   Max/min/mean values of chosen variables
         #   List different missions, each collapsible, with list of sensors from metadata
         #   Data quality flags for chosen variables? (add a link to QC sheets and scripts)

--- a/glider_explorer.py
+++ b/glider_explorer.py
@@ -70,7 +70,7 @@ pn.extension(
     exception_handler=exception_handler,
     notifications=True,
     nthreads=0,
-    defer_load=True,
+    # defer_load=True,
 )
 
 text_opts = hv.opts.Text(text_align="left", text_color="black", fontsize=10)
@@ -308,9 +308,14 @@ class GliderDashboard(param.Parameterized):
 
     def update_markdown(self, x_range, y_range):
         metadata = lod.metadata
-        time_start = self.data_in_view.select("time").first().collect()[0, 0]
-        time_end = self.data_in_view.select("time").last().collect()[0, 0]
-        duration_d = (time_end - time_start).days
+
+        if x_range == (None, None): #   Init to definition in the data
+            time_start = self.data_in_view.select("time").first().collect()[0, 0]
+            time_end = self.data_in_view.select("time").last().collect()[0, 0]
+        else:
+            time_start = x_range[0].astype('datetime64[us]').astype('O')
+            time_end = x_range[1].astype('datetime64[us]').astype('O')
+        duration_d = np.round((time_end - time_start) / np.timedelta64(1, "D"), 1)
         n_prof = int(
             self.data_in_view.select("profile_num").last().collect()[0, 0]
             - self.data_in_view.select("profile_num").first().collect()[0, 0]
@@ -429,6 +434,7 @@ Ocean """
 </div>
 </div>
 """
+        # breakpoint()
         self.markdown.object = (
             p1 + p2 + p3 + p4 + tables_side_by_side
         )  # +r"$$\frac{1}{n}$$"

--- a/glider_explorer.py
+++ b/glider_explorer.py
@@ -333,12 +333,11 @@ class GliderDashboard(param.Parameterized):
         else:
             time_start = x_range[0].astype("datetime64[us]").astype("O")
             time_end = x_range[1].astype("datetime64[us]").astype("O")
-        duration_d = np.round((time_end - time_start) / np.timedelta64(1, "D"), 1)
-        n_prof = int(
-            self.data_in_view.select("profile_num").last().collect()[0, 0]
-            - self.data_in_view.select("profile_num").first().collect()[0, 0]
-        )
-        max_d = self.data_in_view.select("depth").max().collect()[0, 0]
+        duration_d = np.round((time_end - time_start) / np.timedelta64(1, "D"), 1)      
+
+        data_filtered = self.data_in_view.filter((pl.col("time") >= time_start) & (pl.col("time") <= time_end))
+        n_prof = int(data_filtered.select((pl.col("profile_num").max() - (pl.col("profile_num").min()))).collect().item())
+        max_d = data_filtered.select("depth").max().collect().item()
 
         p1 = """\
 # About
@@ -350,13 +349,9 @@ Ocean """
             p1 += description
         if self.pick_toggle == "DatasetID":
             p2 = f""" the datasets {self.pick_dsids} """
-        else:  # self.pick_toggle == "SAMBA obs.":
+        else:  # self.pick_toggle == "SAMBA obs.": Default behavior
             p2 = f"""for the region {self.pick_basin} """
-        # try:
         p3 = f"""from {time_start} to {time_end}. """
-        # except:
-        #    import pdb
-        #    pdb.set_trace()
         p4 = f"""Number of profiles {n_prof}."""
 
         #   Table 1: Basic summary of the view.
@@ -376,10 +371,10 @@ Ocean """
         def var_row(variable):
             """For a specified variable, create a table row with basic stats"""
             try:
-                min_val = self.data_in_view.select(variable).min().collect()[0, 0]
-                max_val = self.data_in_view.select(variable).max().collect()[0, 0]
-                mean_val = self.data_in_view.select(variable).mean().collect()[0, 0]
-                stdev_val = self.data_in_view.select(variable).std().collect()[0, 0]
+                min_val = data_filtered.select(variable).min().collect().item()
+                max_val = data_filtered.select(variable).max().collect().item()
+                mean_val = data_filtered.select(variable).mean().collect().item()
+                stdev_val = data_filtered.select(variable).mean().collect().item()
                 return f"| {variable} | {min_val:.2f} / {max_val:.2f} / {mean_val:.2f} / {stdev_val:.2f} |"
             except Exception as e:
                 print(f"Error calculating stats for {variable}: {e}")

--- a/test_all.py
+++ b/test_all.py
@@ -5,6 +5,7 @@ from os.path import join
 
 import numpy as np
 import panel as pn
+import polars as pl
 
 import glider_explorer as gdb
 
@@ -13,7 +14,7 @@ import glider_explorer as gdb
 # 2. Are datapoints still drawn if zoomed all the way in to a single day?
 # 3. Can the x_range be defined by (url-) parameters?
 # 4. Tipp: I could probably implement tests the same way I implement events.
-outpath = "./test_plots"
+# outpath = "./test_plots"
 
 
 def test_import():
@@ -115,3 +116,25 @@ def test_temperature(tmp_path):
     GDB.pick_cnorm = "linear"
 
     assert 1 == 1
+
+def test_update_markdown():
+    import utils
+    # breakpoint()
+    GDB = gdb.GliderDashboard()
+    x_range = (np.datetime64("2024-01-18"), np.datetime64("2024-12-19"))
+    y_range = (np.float64(0), np.float64(50.5))
+    assert "pick_toggle" in dir(GDB)
+    assert GDB.pick_toggle == "SAMBA obs."  #   Should default to SAMBA
+    assert GDB.pick_variables == ["temperature"]
+
+    #   To make data_on_view, we need to concat the LazyFrames in varlist (get_xsection_raster)
+    GDB.get_xsection_raster(x_range = x_range, y_range = y_range, x = None, y = None)
+    assert type(GDB.data_in_view) is pl.LazyFrame
+
+    output = GDB.update_markdown(x_range = x_range, y_range = y_range)
+
+    # Pulling from data on the server, these values should not change.
+    assert "Bornholm Basin from 2024-01-18 00:00:00 to 2024-12-19 00:00:00" in output
+    assert "Number of Profiles    | 3895" in output
+    assert "| temperature | 2.19 / 10.85 / 5.32 / 2.21 |" in output
+    assert "<tr><td>AD2CP_make_model</td><td>Nortek AD2CP</td></tr>" in output

--- a/test_all.py
+++ b/test_all.py
@@ -23,18 +23,19 @@ def test_import():
 
 def test_dataset_is_loaded():
     # data is loaded
-    assert len(gdb.metadata) > 0
-    print(gdb.metadata)
+    assert len(gdb.lod.metadata) > 0
+    print(gdb.lod.metadata)
 
 
 def test_filter_metadata():
     gdb.utils.year = 2024
     metadata = gdb.utils.filter_metadata()
-    print(len(gdb.metadata))
+    print(len(gdb.lod.metadata))
     print(len(metadata))
 
 
-def test_salinity():
+def test_salinity(tmp_path):
+    # breakpoint()
     GDB = gdb.GliderDashboard()
     # GDB.startX = np.datetime64('2024-03-01')
     # GDB.endX = np.datetime64('2024-05-01')
@@ -48,12 +49,12 @@ def test_salinity():
     t1 = time.perf_counter()
     dyn = GDB.create_dynmap()  # .opts(width=500, height=500)
     # myapp = pn.panel(dyn)
-    dyn.save(join(outpath, "salinity.png"))
+    dyn.save(join(tmp_path, "salinity.png"))
     t2 = time.perf_counter()
     print("creating the first serve took", t2 - t1)
 
 
-def test_temperature():
+def test_temperature(tmp_path):
     GDB = gdb.GliderDashboard()
     # GDB.startX = np.datetime64('2024-03-01')
     # GDB.endX = np.datetime64('2024-05-01')
@@ -65,7 +66,7 @@ def test_temperature():
     t1 = time.perf_counter()
     GDB.pick_variable = "temperature"
     dyn = GDB.create_dynmap()
-    dyn.save(join(outpath, "temperature.png"))
+    dyn.save(join(tmp_path, "temperature.png"))
     t2 = time.perf_counter()
     print("creating the second serve took", t2 - t1)
     t = timeit.Timer(
@@ -89,7 +90,7 @@ def test_temperature():
     GDB.pick_scatter_y = "pressure"
     dyn = GDB.create_dynmap()  # .opts(width=500, height=500)
     myapp = pn.panel(dyn)
-    dyn.save(join(outpath, "TS.png"))
+    dyn.save(join(tmp_path, "TS.png"))
     GDB.pick_TS = False
 
     # activate profile plots
@@ -110,7 +111,7 @@ def test_temperature():
     GDB.cnorm = "eq_hist"
     dyn = GDB.create_dynmap()  # .opts(width=500, height=500)
     myapp = pn.panel(dyn)
-    dyn.save(join(outpath, "eq_hist.png"))
+    dyn.save(join(tmp_path, "eq_hist.png"))
     GDB.pick_cnorm = "linear"
 
     assert 1 == 1

--- a/test_all.py
+++ b/test_all.py
@@ -132,9 +132,9 @@ def test_update_markdown():
     assert type(GDB.data_in_view) is pl.LazyFrame
 
     output = GDB.update_markdown(x_range = x_range, y_range = y_range)
-
+    
     # Pulling from data on the server, these values should not change.
     assert "Bornholm Basin from 2024-01-18 00:00:00 to 2024-12-19 00:00:00" in output
-    assert "Number of Profiles    | 3895" in output
-    assert "| temperature | 2.19 / 10.85 / 5.32 / 2.21 |" in output
+    assert "Number of Profiles    | 3085" in output
+    assert "| temperature | 2.68 / 10.70 / 5.20 / 5.20 |" in output
     assert "<tr><td>AD2CP_make_model</td><td>Nortek AD2CP</td></tr>" in output


### PR DESCRIPTION
Add additional statistics and information to `GliderDashboard.update_markdown` function, helping summarize some of the data that are present including information about the individual deployments and resolving the core desires of #27 .
* Add 3 tables
   * `table1` tabulates the information of `p1` through `p4`.
   * `table2` provides a simple summary (max, min, mean, stdev) for each selected variable within the window view.
   * `table3` extracts metadata for each dataset within the current view.
* Restored functionality to a handful of unit tests.
* Added additional `test_update_markdown` unit test.
* Added Bokeh "reset view" to plot tools.

Note 1: Not tested with large amounts of data for speed.
Note 2: Good starting point for follow-up issue for quality control metrics within the current view, a part of #27 .